### PR TITLE
fix: use default region

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
 	"jkassis.com/cert-secret-syncer/util"
@@ -32,20 +31,15 @@ type SecretSyncer struct {
 	client.Client
 }
 
-var awsSession *session.Session
 var awsAcmSvc *acm.ACM
 
 func init() {
 	// Create ACM service client
-	awsSession = session.Must(session.NewSessionWithOptions(session.Options{
-		Config:            aws.Config{Region: aws.String("us-west-2")},
-		SharedConfigState: session.SharedConfigEnable,
-	}))
-	awsAcmSvc = acm.New(awsSession)
+	awsAcmSvc = acm.New(session.Must(session.NewSession()))
 }
 
 func (r *SecretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
-	log := log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
 	// Get the secret
 	secret := &corev1.Secret{}
@@ -61,7 +55,7 @@ func (r *SecretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (result 
 
 	switch backend {
 	case "ACM":
-		log.Info("reconciling secret with AWS Certificate Manager backend")
+		logger.Info("reconciling secret with AWS Certificate Manager backend")
 
 		// Read certificate and key
 		var certs [][]byte
@@ -87,7 +81,7 @@ func (r *SecretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (result 
 
 		// Import certificate to ACM
 		{
-			log.Info("importing cert to ACM")
+			logger.Info("importing cert to ACM")
 
 			importCertInput := &acm.ImportCertificateInput{
 				Certificate: certs[0],
@@ -159,7 +153,7 @@ func (r *SecretSyncer) ingressesGetByLabels(ctx context.Context, labelSet map[st
 }
 
 func (r *SecretSyncer) labelStringParse(labelString string) (map[string]string, error) {
-	labels := map[string]string{}
+	labelMap := map[string]string{}
 
 	pairs := strings.Split(labelString, ",")
 	for _, pair := range pairs {
@@ -175,10 +169,10 @@ func (r *SecretSyncer) labelStringParse(labelString string) (map[string]string, 
 			return nil, fmt.Errorf("invalid label spec: %q", pair)
 		}
 
-		labels[key] = value
+		labelMap[key] = value
 	}
 
-	return labels, nil
+	return labelMap, nil
 
 }
 


### PR DESCRIPTION
Since the region was hard coded it didn't work for me. I don't see a reason to specify the region.

I also some cleanup to get rid of some linting warnings.

I have quite a lot of other changes in the main branch of my fork, but they are made with the purpose of building and publishing the image and helm chart automatically. So I don't know what is of interest to you.
